### PR TITLE
fix(import-local): Ajout type format pour windows

### DIFF
--- a/src/actions/importLocal/importLocal.js
+++ b/src/actions/importLocal/importLocal.js
@@ -16,17 +16,22 @@ import wasmUrl from 'geoimport/dist/static/gdal3WebAssembly.wasm?url';
 
 import VectorSource from 'ol/source/Vector.js';
 import VectorStyle from 'mcutils/layer/VectorStyle.js';
-// import VectorLayer from 'ol/layer/Vector.js';
 
 const accepted = [
   'application/geo+json',
+  'application/vnd.geo+json', // Obsolète géojson media type
   'application/json',
   'application/vnd.google-earth.kml+xml',
-  'application/geopackage+sqlite3',
-  'application/gpx+xml',
-  'application/zip',
-  'text/csv',
+  'application/geopackage+sqlite3', // Geopackage
+  '.gpkg',
+  'application/gpx+xml', // Gpx
   '.gpx',
+  'application/zip',
+  'application/x-zip-compressed', // Windows zip
+  'application/x-7z-compressed', // Fichiers 7zip
+  '.zip',
+  'text/csv',
+  'application/vnd.ms-excel', // Windows csv
 ]
 // Fichiers excel :
 // 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',


### PR DESCRIPTION
Ajout des extensions suivantes pour que les formats soient bien reconnus par windows :

- 'application/vnd.geo+json',
- '.gpkg', (il y'avait déjà 'application/geopackage+sqlite3' qui est le bon media type pour le géopackage).
- 'application/vnd.ms-excel' (conformément aux screens de l'issue #35, mais cela pourrait poser problème avec des fichiers excels ?).
- 'application/x-zip-compressed', (manière dont windows traite les fichiers zip, mais ce n'est pas un media type enregistré officiellement).
- 'application/x-7z-compressed' (pour les fichier 7zip).
- '.zip', (ajout de l'extension pour que cela soit plus pratique).

Close #35